### PR TITLE
feat: add pretest script to run build before tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"git:test-staged": "which node && node -v && node --test ./packages/*",
 		"lint": "biome check --write --no-errors-on-unmatched",
 		"build": "bin/esbuild",
+		"pretest": "npm run build",
 		"test": "npm run test:lint && npm run test:unit && npm run test:types && npm run test:sast && npm run test:perf && npm run test:dast",
 		"test:lint": "biome check --staged --no-errors-on-unmatched",
 		"test:unit": "npm run test:unit:node && npm run test:unit:web",


### PR DESCRIPTION
## Summary
- Add `"pretest": "npm run build"` so that `npm test` automatically builds first
- Ensures tests always run against freshly built artifacts

## Test plan
- [ ] Verify `npm test` triggers build first
- [ ] Verify CI `Tests (unit)` etc. pick up latest build